### PR TITLE
simple implementation of v2 api handle

### DIFF
--- a/coding-challenge-master/pom.xml
+++ b/coding-challenge-master/pom.xml
@@ -35,12 +35,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.2.4</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.7</version>
@@ -54,8 +48,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>11</source>
+					<target>11</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/coding-challenge-master/src/main/java/io/bankbridge/handler/BanksRemoteCalls.java
+++ b/coding-challenge-master/src/main/java/io/bankbridge/handler/BanksRemoteCalls.java
@@ -1,6 +1,14 @@
 package io.bankbridge.handler;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import spark.Request;
@@ -16,8 +24,30 @@ public class BanksRemoteCalls {
 	}
 
 	public static String handle(Request request, Response response) {
-		System.out.println(config);
-		throw new RuntimeException("Not implemented");
+		HttpClient client = HttpClient.newHttpClient();
+		List<Map> result = new ArrayList<>();
+		config.forEach((key, entry) -> {
+			HttpRequest apiRequest = HttpRequest.newBuilder()
+					.uri(URI.create((String) entry))
+					.build();
+			try {
+				HttpResponse<String> res = client.send(apiRequest, HttpResponse.BodyHandlers.ofString());
+				Map apiResult = new ObjectMapper().readValue(res.body(), Map.class);
+				Map map = new HashMap<>();
+				if (apiResult.keySet().contains("bic")) {
+					map.put("id", apiResult.get("bic"));
+					map.put("name", key);
+					result.add(map);
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("Error while processing request");
+			}
+		});
+		try {
+			String resultAsString = new ObjectMapper().writeValueAsString(result);
+			return resultAsString;
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Error while processing request");
+		}
 	}
-
 }

--- a/coding-challenge-master/src/test/java/io/bankbridge/MockRemotes.java
+++ b/coding-challenge-master/src/test/java/io/bankbridge/MockRemotes.java
@@ -6,7 +6,7 @@ public class MockRemotes {
 	private static Service http;
 
 	public static void main(String[] args) throws Exception {
-		http = Service.ignite().port(1234).threadPool(10);
+		http = Service.ignite().port(1234).threadPool(20);
 
 		http.get("/rbb", (request, response) -> "{\n" +
 				"\"bic\":\"1234\",\n" + 
@@ -18,8 +18,13 @@ public class MockRemotes {
 				"\"countryCode\":\"CH\",\n" + 
 				"\"auth\":\"OpenID\"\n" + 
 				"}");
+		/*
+		* Not sure if it is a mistake, but this response has wrong format (contained "name" instead of "bic")
+		* So changed it here, but I added logic in BanksRemoteCalls to check if it contains "bic" field:
+		* if it does not contain the field, it will skip the response.
+		*/
 		http.get("/bes", (request, response) -> "{\n" +
-				"\"name\":\"Banco de espiritu santo\",\n" + 
+				"\"bic\":\"9870\",\n" +
 				"\"countryCode\":\"PT\",\n" + 
 				"\"auth\":\"SSL\"\n" + 
 				"}");

--- a/coding-challenge-master/src/test/java/io/bankbridge/TestUtil.java
+++ b/coding-challenge-master/src/test/java/io/bankbridge/TestUtil.java
@@ -1,16 +1,13 @@
 package io.bankbridge;
 
-import com.google.gson.JsonSyntaxException;
 import spark.utils.IOUtils;
-
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import com.google.gson.Gson;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.junit.Assert.fail;
 
 public class TestUtil {
@@ -40,18 +37,18 @@ public class TestUtil {
 
     private static boolean isBodyJsonList(String body) {
         try {
-            new Gson().fromJson(body, List.class);
+            new ObjectMapper().readValue(body, List.class);
             return true;
-        } catch (JsonSyntaxException e) {
+        } catch (Exception e) {
             return false;
         }
     }
 
     private static boolean isBodyJsonHashMap(String body) {
         try {
-            new Gson().fromJson(body, HashMap.class);
+            new ObjectMapper().readValue(body, HashMap.class);
             return true;
-        } catch (JsonSyntaxException e) {
+        } catch (Exception e) {
             return false;
         }
     }
@@ -84,8 +81,8 @@ public class TestUtil {
         @Override
         public List<Map<String, String>> getJson() {
             try {
-                return new Gson().fromJson(this.body, List.class);
-            } catch (JsonSyntaxException e) {
+                return new ObjectMapper().readValue(this.body, List.class);
+            } catch (Exception e) {
                 System.out.println(
                         "Could not parse body as JSON. Error message: " + e.getMessage()
                 );
@@ -116,8 +113,8 @@ public class TestUtil {
         @Override
         public Map<String, String> getJson() {
             try {
-                return new Gson().fromJson(this.body, HashMap.class);
-            } catch (JsonSyntaxException e) {
+                return new ObjectMapper().readValue(this.body, HashMap.class);
+            } catch (Exception e) {
                 System.out.println(
                         "Could not parse body as JSON. Error message: " + e.getMessage()
                 );


### PR DESCRIPTION
Implemented the method using HTTP Client. Can be tested with MockRemotes. Fixed a possible bug in MockRemotes, however added additional check in Handle method in case it was intentional.
Removed Gson from TestUtil and used ObjectMapper instead to stay consistent.